### PR TITLE
Add slash if missing slash

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 Zendesk
+Copyright 2018 Zendesk
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,3 +11,38 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+ADDITIONAL TERMS AND CONDITIONS
+
+Capitalized terms used herein have the meaning set forth in the
+Zendesk, Inc. (“Zendesk”) Master Subscription Agreement (available at https://www.zendesk.com/company/customers-partners/#master-subscription-agreement)
+(the "MSA"). The software made available herein constitutes the source code for a
+Zendesk Application (“Application Software”) which may be implemented to
+enable features or functionality to be utilized in connection with a subscription
+to the Service.  Notwithstanding anything to the contrary set forth in the MSA
+or any other agreement by and between you and Zendesk, Application Software is
+provided “AS IS” and on an “AS AVAILABLE” basis, and that Zendesk makes no warranty
+as to the Application Software.  ZENDESK DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT AND THOSE ARISING FROM A COURSE
+OF DEALING OR USAGE OF TRADE RELATED TO THE APPLICATION SOFTWARE, ITS USE OR ANY INABILITY
+TO USE IT OR THE RESULTS OF ITS USE.
+
+Zendesk makes Zendesk Applications available for use through the user interface of
+the Service in the manner described (for each Zendesk Application) at www.zendesk.com/apps
+(“Service Implementation”).  Use of Application Software, other than in connection with a
+Service Implementation is subject to the following risks and conditions:  (i) the Application
+Software may contain errors, design flaws or other problems; and (ii)  use of the Application
+Software may result in unexpected results, loss of data, project delays or other unpredictable
+damage or loss.  Zendesk only supports the Application Software currently available and installed
+through the Service Implementation.  By utilizing Application Software other than in connection
+with the Service Implementation, you are agreeing that Zendesk shall have no obligation to
+correct any bugs, defects or errors in the Application Software you have utilized or
+otherwise to support or maintain the Application Software you have utilized.
+
+If you elect to utilize any Application Software other than through a Service Implementation,
+you are agreeing to release Zendesk from any claim with regard to the Application Software,
+its operation, availability or its failure to operate or be available.
+Without limiting the generality of the foregoing, You acknowledge and agree that neither the use,
+availability nor operation of any Application Software shall be subject to any service level
+commitment applicable to the Service.

--- a/assets/iframe.js
+++ b/assets/iframe.js
@@ -11,7 +11,8 @@ function buildUrl (currentUrl, newUrl) {
   }
   var settingsUrl = urlParser(newUrl)
   var newParams = [].concat(queryParameters(currentUrl), queryParameters(newUrl)).join('&')
-  return settingsUrl.protocol + '//' + settingsUrl.host + settingsUrl.pathname + '?' + newParams + settingsUrl.hash
+  var insertIEslash = settingsUrl.pathname.indexOf('/') === 0 ? '' : '/' // IE doesn't start pathname with a slash
+  return settingsUrl.protocol + '//' + settingsUrl.host + insertIEslash + settingsUrl.pathname + '?' + newParams + settingsUrl.hash
 }
 
 function urlParser (url) {


### PR DESCRIPTION
### Description
Fix for: IE11 doesn't start `pathname` with a slash. Add a slash if slash is missing.